### PR TITLE
feat: bump naar league/glide v3 voor OC 4.1+ compatibiliteit (v5.0.0)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.0, 8.1, 8.2, 8.3 ]
+        php: [ 8.2, 8.3, 8.4, 8.5 ]
         stability: [ prefer-lowest, prefer-stable ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
@@ -45,7 +45,7 @@ jobs:
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --prefer-dist --no-progress
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-05-27
+
+- Add support for October CMS 4.1 and 4.2
+- Bump `league/glide` to `^3.0` (Glide v3, intervention/image v3)
+- Bump `league/glide-symfony` to `^2.1` (first stable release allowing Glide v3)
+- Minimum required PHP version is now 8.2 (Glide v3 requirement)
+
 ## [4.0.0] - 2025-08-20
 
 - Add support for October CMS 4.x

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Glide leverages powerful libraries like Intervention Image (for image handling a
 
 ## Requirements
 
-* PHP 8.0.2 or higher
+* PHP 8.2 or higher
 * PHP extensions:
   * ext-exif
-* October CMS 3.x or higher
+* October CMS 3.x, 4.x, 4.1.x or 4.2.x
 
 ## Installation
 
@@ -36,7 +36,7 @@ GLIDE_SIGN_KEY="[YOUR SIGN KEY HERE]"
 
 > We recommend using a 128 character (or larger) signing key to prevent trivial key attacks. Consider using a package like [CryptoKey](https://github.com/AndrewCarterUK/CryptoKey) to generate a secure key.
 
-For more details about the security and why a sign key is used, check [glide.thephpleague.com](https://glide.thephpleague.com/2.0/config/security/).
+For more details about the security and why a sign key is used, check [glide.thephpleague.com](https://glide.thephpleague.com/3.0/config/security/).
 
 Add an url to your disk in the `config/filesystem.php` to display the images properly, for example:
 

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.2",
         "ext-exif": "*",
         "composer/installers": "^1.0 || ^2.0",
-        "league/glide": "^2.0",
-        "league/glide-symfony": "^2.0",
-        "october/rain": "^3.0 || ^4.0"
+        "league/glide": "^3.0",
+        "league/glide-symfony": "^2.1",
+        "october/rain": "^3.0 || ^4.0 || ^4.1 || ^4.2"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42"

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -8,3 +8,4 @@ v3.0.1: Add missing CHANGELOG file
 v3.1.0: Maintenance release
 v3.2.0: Add support for October CMS 3.0
 v4.0.0: See CHANGELOG.md for details
+v5.0.0: See CHANGELOG.md for details


### PR DESCRIPTION
## Summary

Bumps `vdlp/oc-glide-plugin` to **5.0.0** to make it composer-resolvable against OctoberCMS 4.1+. Without this bump, every project that depends on this plugin (directly or transitively via `vdlp/sections`) hits a hard composer resolve-fail  when bumping to OC 4.1+, because OC 4.1+ requires `intervention/image ^3.10` while `league/glide ^2.0` clamps to `intervention/image ^2.x`.

## Changes
### Dependency bumps (`composer.json`)

- `php`: `^8.0.2` → `^8.2` (Glide v3 requirement)
- `league/glide`: `^2.0` → `^3.0`
- `league/glide-symfony`: `^2.0` → `^2.1` (first stable release that allows Glide v3)
- `october/rain`: range extended with `^4.1` and `^4.2`

### Release metadata

- `updates/version.yaml`: new `v5.0.0` entry
- `CHANGELOG.md`: new `## [5.0.0]` block

### Documentation & CI

- `README.md`: requirements updated to PHP 8.2+ and OC 3.x through 4.2.x; Glide doc-link bumped from `/2.0/` to `/3.0/`.
- `.github/workflows/php.yml`: PHP matrix moved from 8.0–8.3 to 8.2–8.5; removed deprecated `--no-suggest` composer flag.

## No code changes

Glide v3's public API is identical to v2 for the keys this plugin uses: `ServerFactory::create`, `SymfonyResponseFactory`, `SignatureFactory`, `UrlBuilderFactory`, `Server::makeImage`, `Server::setResponseFactory`, `Server::getImageResponse`. Verified by reading `classes/GlideManager.php`, `classes/GlideHelper.php`, and `controllers/Image.php`.

## Test plan

Verified locally against a real OctoberCMS 4.2.22 project using a composer path-repository pointing to this branch:

- `composer update --with-all-dependencies` resolves to `league/glide 3.2.0`, `league/glide-symfony 2.1.0`, `intervention/image 3.11.8`
- `php artisan october:migrate` runs without fatals (Vdlp.Glide registered as v5.0.0)
- `GlideManager::server()` returns `League\Glide\Server`
- `Server::makeImage('media/test.jpg', ['w' => 200, 'h' => 200, 'fit' => 'crop'])` produces a valid 200×200 `image/jpeg` response